### PR TITLE
New zombie behaviors from java and Bedrock

### DIFF
--- a/resourcepacks/vanilla/server/entities/zombie.json
+++ b/resourcepacks/vanilla/server/entities/zombie.json
@@ -7,30 +7,127 @@
         "minecraft:is_baby": { },
         "minecraft:scale": {
           "value": 0.5
-        },		
+        },
         "minecraft:movement": {
           "value": 0.35
         }
       },
 
+	  "minecraft:door_smash": {
+		  "minecraft:behavior.break_door": {
+			"priority": 2
+		  }  
+	 },
+	  "minecraft:leader": {
+	   "minecraft:behavior.summon_entity": {
+        "priority": 1,
+
+        "summon_choices": [
+          {
+            "min_activation_range": 0.0,
+            "max_activation_range": 12.0,
+            "cooldown_time": 25.0,
+            "weight": 8,
+            "cast_duration": 0.2,
+            "particle_color": "#00664D59",
+            "start_sound_event": "cast.spell",
+            "sequence": [
+              {
+                "shape": "circle",
+                "target": "self",
+                "base_delay": 0.2,
+                "delay_per_summon": 0.0,
+                "num_entities_spawned": 1,
+                "entity_type": "minecraft:zombie",
+                "summon_cap": 2,
+                "summon_cap_radius": 40.0,				
+                "size": 1,
+                "sound_event": "prepare.summon"
+              },
+              {
+                "shape": "circle",
+                "target": "self",
+                "base_delay": 0.15,
+                "delay_per_summon": 0.1,
+                "num_entities_spawned": 1,
+                "entity_type": "minecraft:zombie",
+                "summon_cap": 2,
+                "summon_cap_radius": 40.0,				
+                "size": 1,
+				"sound_event": "prepare.summon"			
+              }
+            ]
+          },
+          {
+            "min_activation_range": 2.0,
+            "weight": 6,
+            "cooldown_time": 30.0,
+            "cast_duration": 0.2,
+            "particle_color": "#00664D59",
+            "start_sound_event": "cast.spell",
+            "sequence": [
+              {
+                "shape": "line",
+                "target": "self",
+                "base_delay": 0.1,
+                "delay_per_summon": 0.1,
+                "num_entities_spawned": 1,
+                "entity_type": "minecraft:zombie",
+				"summon_cap": 2,	
+                "size": 1,
+                "summon_cap_radius": 40.0,				
+				"sound_event": "prepare.summon"	
+              }
+            ]
+          },
+          {
+            "weight": 5,
+            "cooldown_time": 35.0,
+            "cast_duration": 0.1,
+            "particle_color": "#00B3B3CC",
+            "sequence": [
+              {
+                "shape": "circle",
+                "target": "self",
+                "base_delay": 5.0,
+                "num_entities_spawned": 1,
+                "entity_type": "minecraft:zombie",
+                "summon_cap": 2,
+                "summon_cap_radius": 40.0,
+                "size": 1,
+                "sound_event": "prepare.summon"
+              }
+            ]
+          }
+        ]
+      }			  
+	 },
+	 
       "minecraft:zombie_adult": {
         "minecraft:movement": {
-          "value": 0.25
-        },
-        "minecraft:burns_in_daylight": {
+          "value": 0.23
         },
         "minecraft:behavior.mount_pathing": {
           "priority": 2,
-          "speed_multiplier": 1.2,
+          "speed_multiplier": 1.25,
           "target_dist": 0.0,
           "track_target": true
+        },
+      "minecraft:rideable": {
+        "seat_count": 1,
+        "family_types": [
+           "zombie"
+        ],
+        "seats": {
+          "position": [0, 1.10, -0.5]
         }
+       }		
       },
 
       "minecraft:zombie_jockey": {
         "minecraft:behavior.find_mount": {
           "priority": 1,
-          "within_radius": 16
+          "within_radius": 12	  
         }
       }
     },
@@ -41,6 +138,8 @@
       },
       "minecraft:nameable": {
       },
+	  "minecraft:burns_in_daylight": {
+	  },
 
       // Zombie Components
       "minecraft:type_family": {
@@ -73,90 +172,8 @@
         "suffocateTime": 0
       },
       "minecraft:attack": {
-        "damage": 4
+        "damage": 3
       },
-	   "minecraft:behavior.summon_entity": {
-        "priority": 1,
-
-        "summon_choices": [
-          {
-            "min_activation_range": 0.0,
-            "max_activation_range": 12.0,
-            "cooldown_time": 25.0,
-            "weight": 4,
-            "cast_duration": 0.2,
-            "particle_color": "#00664D59",
-            "start_sound_event": "cast.spell",
-            "sequence": [
-              {
-                "shape": "circle",
-                "target": "self",
-                "base_delay": 0.7,
-                "delay_per_summon": 0.0,
-                "num_entities_spawned": 1,
-                "entity_type": "minecraft:zombie",
-                "summon_cap": 3,
-                "summon_cap_radius": 40.0,				
-                "size": 1.5,
-                "sound_event": "prepare.summon"
-              },
-              {
-                "shape": "circle",
-                "target": "self",
-                "base_delay": 0.15,
-                "delay_per_summon": 0.1,
-                "num_entities_spawned": 1,
-                "entity_type": "minecraft:zombie",
-                "summon_cap": 3,
-                "summon_cap_radius": 40.0,				
-                "size": 1.5,
-				"sound_event": "prepare.summon"			
-              }
-            ]
-          },
-          {
-            "min_activation_range": 2.0,
-            "weight": 7,
-            "cooldown_time": 30.0,
-            "cast_duration": 0.2,
-            "particle_color": "#00664D59",
-            "start_sound_event": "cast.spell",
-            "sequence": [
-              {
-                "shape": "line",
-                "target": "self",
-                "base_delay": 1.0,
-                "delay_per_summon": 0.1,
-                "num_entities_spawned": 1,
-                "entity_type": "minecraft:zombie",
-				"summon_cap": 3,	
-                "size": 1.5,
-                "summon_cap_radius": 40.0,				
-				"sound_event": "prepare.summon"	
-              }
-            ]
-          },
-          {
-            "weight": 8,
-            "cooldown_time": 35.0,
-            "cast_duration": 3.0,
-            "particle_color": "#FFB3B3CC",
-            "sequence": [
-              {
-                "shape": "circle",
-                "target": "self",
-                "base_delay": 5.0,
-                "num_entities_spawned": 1,
-                "entity_type": "minecraft:zombie",
-                "summon_cap": 3,
-                "summon_cap_radius": 40.0,
-                "size": 1.0,
-                "sound_event": "prepare.summon"
-              }
-            ]
-          }
-        ]
-      },	  
       "minecraft:loot": {
         "table": "loot_tables/entities/zombie.json"
       },
@@ -164,9 +181,6 @@
       // Zombie Behaviors
       "minecraft:behavior.float": {
         "priority": 0
-      },
-      "minecraft:behavior.break_door": {
-        "priority": 1
       },
       "minecraft:behavior.melee_attack": {
         "priority": 3,
@@ -192,16 +206,13 @@
       "minecraft:behavior.hurt_by_target": {
         "priority": 1
       },
-      "minecraft:behavior.charge_attack": {
-        "priority": 4
-      },	  
       "minecraft:behavior.nearest_attackable_target": {
-        "priority": 4,
+        "priority": 2,
         "within_radius": 25,
         "entity_types": [
           {
             "filters": { "other_with_families": [ "player", "irongolem", "snowgolem", "villager" ] },
-            "max_dist": 45
+            "max_dist": 35
           }
         ]
       }
@@ -211,7 +222,7 @@
       "minecraft:entity_spawned": {
         "randomize": [
           {
-            "weight": 380,
+            "weight": 110,
             "remove": {
             },
             "add": {
@@ -221,18 +232,44 @@
             }
           },
           {
-            "weight": 17,
+            "weight": 70,
             "remove": {
             },
             "add": {
               "component_groups": [
-                "minecraft:zombie_baby"
+                "minecraft:zombie_adult",
+				"minecraft:leader"			
+              ]
+            }
+          },		  
+          {
+			"filters": {
+			  "is_world_difficulty": "hard"
+			},			  
+            "weight": 100,
+            "remove": {
+            },
+            "add": {
+              "component_groups": [
+                "minecraft:zombie_adult",
+				"minecraft:door_smash"	
+              ]
+            }
+          },		  
+          {
+            "weight": 20,
+            "remove": {
+            },
+            "add": {
+              "component_groups": [
+                "minecraft:zombie_baby",
+                "minecraft:zombie_jockey"				
               ]
 
             }
           },
           {
-            "weight": 3,
+            "weight": 20,
             "remove": {
             },
             "add": {

--- a/zombie.json
+++ b/zombie.json
@@ -1,0 +1,286 @@
+{
+  "minecraft:entity": {
+    "format_version": "1.1.0",
+
+    "component_groups": {
+      "minecraft:zombie_baby": {
+        "minecraft:is_baby": { },
+        "minecraft:scale": {
+          "value": 0.5
+        },
+        "minecraft:movement": {
+          "value": 0.35
+        }
+      },
+
+	  "minecraft:door_smash": {
+		  "minecraft:behavior.break_door": {
+			"priority": 2
+		  }  
+	 },
+	  "minecraft:leader": {
+	   "minecraft:behavior.summon_entity": {
+        "priority": 1,
+
+        "summon_choices": [
+          {
+            "min_activation_range": 0.0,
+            "max_activation_range": 12.0,
+            "cooldown_time": 25.0,
+            "weight": 8,
+            "cast_duration": 0.2,
+            "particle_color": "#00664D59",
+            "start_sound_event": "cast.spell",
+            "sequence": [
+              {
+                "shape": "circle",
+                "target": "self",
+                "base_delay": 0.2,
+                "delay_per_summon": 0.0,
+                "num_entities_spawned": 1,
+                "entity_type": "minecraft:zombie",
+                "summon_cap": 2,
+                "summon_cap_radius": 40.0,				
+                "size": 1,
+                "sound_event": "prepare.summon"
+              },
+              {
+                "shape": "circle",
+                "target": "self",
+                "base_delay": 0.15,
+                "delay_per_summon": 0.1,
+                "num_entities_spawned": 1,
+                "entity_type": "minecraft:zombie",
+                "summon_cap": 2,
+                "summon_cap_radius": 40.0,				
+                "size": 1,
+				"sound_event": "prepare.summon"			
+              }
+            ]
+          },
+          {
+            "min_activation_range": 2.0,
+            "weight": 6,
+            "cooldown_time": 30.0,
+            "cast_duration": 0.2,
+            "particle_color": "#00664D59",
+            "start_sound_event": "cast.spell",
+            "sequence": [
+              {
+                "shape": "line",
+                "target": "self",
+                "base_delay": 0.1,
+                "delay_per_summon": 0.1,
+                "num_entities_spawned": 1,
+                "entity_type": "minecraft:zombie",
+				"summon_cap": 2,	
+                "size": 1,
+                "summon_cap_radius": 40.0,				
+				"sound_event": "prepare.summon"	
+              }
+            ]
+          },
+          {
+            "weight": 5,
+            "cooldown_time": 35.0,
+            "cast_duration": 0.1,
+            "particle_color": "#00B3B3CC",
+            "sequence": [
+              {
+                "shape": "circle",
+                "target": "self",
+                "base_delay": 5.0,
+                "num_entities_spawned": 1,
+                "entity_type": "minecraft:zombie",
+                "summon_cap": 2,
+                "summon_cap_radius": 40.0,
+                "size": 1,
+                "sound_event": "prepare.summon"
+              }
+            ]
+          }
+        ]
+      }			  
+	 },
+	 
+      "minecraft:zombie_adult": {
+        "minecraft:movement": {
+          "value": 0.23
+        },
+        "minecraft:behavior.mount_pathing": {
+          "priority": 2,
+          "speed_multiplier": 1.25,
+          "target_dist": 0.0,
+          "track_target": true
+        },
+      "minecraft:rideable": {
+        "seat_count": 1,
+        "family_types": [
+           "zombie"
+        ],
+        "seats": {
+          "position": [0, 1.10, -0.5]
+        }
+       }		
+      },
+
+      "minecraft:zombie_jockey": {
+        "minecraft:behavior.find_mount": {
+          "priority": 1,
+          "within_radius": 12	  
+        }
+      }
+    },
+
+    "components": {
+      "minecraft:identifier": {
+        "id": "minecraft:zombie"
+      },
+      "minecraft:nameable": {
+      },
+	  "minecraft:burns_in_daylight": {
+	  },
+
+      // Zombie Components
+      "minecraft:type_family": {
+        "family": [ "zombie", "undead", "monster" ]
+      },
+      "minecraft:collision_box": {
+        "width": 0.6,
+        "height": 1.8
+      },
+      "minecraft:equipment": {
+        "table": "loot_tables/entities/zombie_equipment.json"
+      },
+      "minecraft:navigation.walk": {
+        "can_float": true,
+        "can_pass_doors": true,
+        "can_open_doors": true
+      },
+      "minecraft:movement.basic": {
+      },
+      "minecraft:jump.static": {
+      },
+      "minecraft:can_climb": {
+      },
+      "minecraft:health": {
+        "value": 20,
+        "max": 20
+      },
+      "minecraft:breathable": {
+        "totalSupply": 15,
+        "suffocateTime": 0
+      },
+      "minecraft:attack": {
+        "damage": 3
+      },
+      "minecraft:loot": {
+        "table": "loot_tables/entities/zombie.json"
+      },
+
+      // Zombie Behaviors
+      "minecraft:behavior.float": {
+        "priority": 0
+      },
+      "minecraft:behavior.melee_attack": {
+        "priority": 3,
+        "speed_multiplier": 1,
+        "track_target": false
+      },
+      "minecraft:behavior.move_towards_restriction": {
+        "priority": 4,
+        "speed_multiplier": 1
+      },
+      "minecraft:behavior.random_stroll": {
+        "priority": 6,
+        "speed_multiplier": 1
+      },
+      "minecraft:behavior.look_at_player": {
+        "priority": 7,
+        "look_distance": 6,
+        "probability": 0.02
+      },
+      "minecraft:behavior.random_look_around": {
+        "priority": 7
+      },
+      "minecraft:behavior.hurt_by_target": {
+        "priority": 1
+      },
+      "minecraft:behavior.nearest_attackable_target": {
+        "priority": 2,
+        "within_radius": 25,
+        "entity_types": [
+          {
+            "filters": { "other_with_families": [ "player", "irongolem", "snowgolem", "villager" ] },
+            "max_dist": 35
+          }
+        ]
+      }
+    },
+
+    "events": {
+      "minecraft:entity_spawned": {
+        "randomize": [
+          {
+            "weight": 110,
+            "remove": {
+            },
+            "add": {
+              "component_groups": [
+                "minecraft:zombie_adult"
+              ]
+            }
+          },
+          {
+            "weight": 70,
+            "remove": {
+            },
+            "add": {
+              "component_groups": [
+                "minecraft:zombie_adult",
+				"minecraft:leader"			
+              ]
+            }
+          },		  
+          {
+			"filters": {
+			  "is_world_difficulty": "hard"
+			},			  
+            "weight": 100,
+            "remove": {
+            },
+            "add": {
+              "component_groups": [
+                "minecraft:zombie_adult",
+				"minecraft:door_smash"	
+              ]
+            }
+          },		  
+          {
+            "weight": 20,
+            "remove": {
+            },
+            "add": {
+              "component_groups": [
+                "minecraft:zombie_baby",
+                "minecraft:zombie_jockey"				
+              ]
+
+            }
+          },
+          {
+            "weight": 20,
+            "remove": {
+            },
+            "add": {
+              "component_groups": [
+                "minecraft:zombie_baby",
+                "minecraft:zombie_jockey"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
First pull request and commit, accidentally added the json in the wrong place and had to delete then reimport it in the correct folder, WHOOPS.

Adds bug fixes to babies not burning in sunlight, zombies attempting to break down doors outside of hardmode, adds the "leader" trait from java edition in which rarely a zombie will spawn with the ability to summon backup, changed breaking down doors to be a rare trait adults can spawn with and finally added baby zombies piggy-backing adult zombies from bedrock.