### PR TITLE
optimize loot tables, and undo zillager parity change

### DIFF
--- a/resourcepacks/vanilla/server/entities/boat.json
+++ b/resourcepacks/vanilla/server/entities/boat.json
@@ -1,0 +1,52 @@
+{
+  "minecraft:entity": {
+    "format_version": "1.1.0",
+
+    "component_groups": {
+    },
+
+    "components": {
+      "minecraft:identifier": {
+        "id": "minecraft:boat"
+      },
+      "minecraft:collision_box": {
+        "width": 1.4,
+        "height": 0.455
+      },
+      "minecraft:rideable": {
+        "seat_count": 2,
+        "interact_text": "action.interact.ride.boat",
+        "seats": [
+          {
+            "position": [0.0, -0.2, 0.0],
+            "min_rider_count": 0,
+            "max_rider_count": 1,
+
+            "rotate_rider_by": -90,
+            "lock_rider_rotation": 90
+          },
+          {
+            "position": [0.2, -0.2, 0.0],
+            "min_rider_count": 2,
+            "max_rider_count": 2,
+
+            "rotate_rider_by": -90,
+            "lock_rider_rotation": 90
+          },
+          {
+            "position": [ -0.6, -0.2, 0.0],
+            "min_rider_count": 2,
+            "max_rider_count": 2,
+
+            "lock_rider_rotation": 90
+          }
+        ]
+      },
+      "minecraft:is_stackable": {
+      }      
+    },
+
+    "events": {
+    }
+  }
+}

--- a/resourcepacks/vanilla/server/entities/llama.json
+++ b/resourcepacks/vanilla/server/entities/llama.json
@@ -1,0 +1,628 @@
+{
+  "minecraft:entity": {
+    "format_version": "1.1.0",
+
+    "component_groups": {
+      "minecraft:llama_baby": {
+        "minecraft:is_baby": {
+        },
+        "minecraft:scale": {
+          "value": 0.5
+        },
+        "minecraft:ageable": {
+          "duration": 1200,
+          "feedItems": [
+            {
+              "item": "wheat",
+              "growth": 0.1
+            },
+            {
+              "item": "tile.hay_block",
+              "growth": 0.9
+            }
+          ],
+          "grow_up": {
+            "event": "minecraft:ageable_grow_up",
+            "target": "self"
+          }
+        },
+
+        "minecraft:behavior.follow_parent": {
+          "priority": 5,
+          "speed_multiplier": 1.0
+        }
+      },
+
+      "minecraft:llama_adult": {
+        "minecraft:loot": {
+          "table": "loot_tables/entities/horse.json"
+        },
+        "minecraft:collision_box": {
+          "width": 0.9,
+          "height": 1.87
+        },
+        "minecraft:behavior.breed": {
+          "priority": 4,
+          "speed_multiplier": 1.0
+        },
+        "minecraft:breedable": {
+          "requireTame": true,
+          "inheritTamed": false,
+          "breedsWith": {
+            "mateType": "minecraft:llama",
+            "babyType": "minecraft:llama",
+            "breed_event": {
+              "event": "minecraft:entity_born",
+              "target": "baby"
+            }
+          },
+          "breedItems": [ "tile.hay_block" ]
+        }
+      },
+
+      "minecraft:strength_1": {
+        "minecraft:strength": {
+          "value": 1,
+          "max": 5
+        }
+      },
+      "minecraft:strength_2": {
+        "minecraft:strength": {
+          "value": 2,
+          "max": 5
+        }
+      },
+      "minecraft:strength_3": {
+        "minecraft:strength": {
+          "value": 3,
+          "max": 5
+        }
+      },
+      "minecraft:strength_4": {
+        "minecraft:strength": {
+          "value": 4,
+          "max": 5
+        }
+      },
+      "minecraft:strength_5": {
+        "minecraft:strength": {
+          "value": 5,
+          "max": 5
+        }
+      },
+
+      "minecraft:llama_creamy": {
+        "minecraft:variant": {
+          "value": 0
+        }
+      },
+      "minecraft:llama_white": {
+        "minecraft:variant": {
+          "value": 1
+        }
+      },
+      "minecraft:llama_brown": {
+        "minecraft:variant": {
+          "value": 2
+        }
+      },
+      "minecraft:llama_gray": {
+        "minecraft:variant": {
+          "value": 3
+        }
+      },
+
+      "minecraft:llama_wild": {
+        "minecraft:rideable": {
+          "seat_count": 1,
+          "family_types": [
+            "player"
+          ],
+          "interact_text": "action.interact.mount",
+          "seats": {
+            "position": [ 0.0, 1.25, -0.3 ]
+          }
+
+        },
+        "minecraft:tamemount": {
+          "minTemper": 0,
+          "maxTemper": 30,
+          "feed_text": "action.interact.feed",
+          "ride_text": "action.interact.mount",
+          "feedItems": [
+            {
+              "item": "wheat",
+              "temperMod": 3
+            },
+            {
+              "item": "tile.hay_block",
+              "temperMod": 6
+            }
+          ],
+          "autoRejectItems": [
+            {
+              "item": "horsearmorleather"
+            },
+            {
+              "item": "horsearmoriron"
+            },
+            {
+              "item": "horsearmorgold"
+            },
+            {
+              "item": "horsearmordiamond"
+            },
+            {
+              "item": "saddle"
+            }
+          ],
+          "tame_event": {
+            "event": "minecraft:on_tame",
+            "target": "self"
+          }
+        }
+      },
+
+
+      "minecraft:llama_tamed": {
+        "minecraft:is_tamed": {
+        },
+        "minecraft:rideable": {
+          "priority": 0,
+          "seat_count": 1,
+          "crouching_skip_interact": true,
+          "family_types": [
+            "player"
+          ],
+          "interact_text": "action.interact.ride.horse",
+          "seats": {
+            "position": [ 0.0, 1.1, -0.2 ]
+          }
+
+        },
+        "minecraft:inventory": {
+          "inventory_size": 16,
+          "container_type": "horse",
+          "additional_slots_per_strength": 3
+        },
+        "minecraft:equippable": {
+          "slots": [
+            {
+              "slot": 1,
+              "item": "carpet",
+              "accepted_items": [ "carpet" ]
+            }
+          ]
+        }
+      },
+      "minecraft:llama_unchested": {
+        "minecraft:interact": [
+          {
+            "on_interact": {
+              "filters": {
+                "other_with_item": "chest:0",
+                "other_with_families": "player"
+              },
+              "event": "minecraft:on_chest",
+              "target": "self"
+            },
+            "use_item": "true",
+            "interact_text": "action.interact.attachchest"
+          }
+        ]
+      },
+
+      "minecraft:llama_chested": {
+        "minecraft:is_chested": {
+
+        }
+      },
+
+      "minecraft:llama_leashed": {
+        "minecraft:behavior.move_towards_restriction": {
+          "priority": 2,
+          "speed_multiplier": 1.0
+        }
+      },
+
+      "minecraft:llama_angry": {
+        "minecraft:angry": {
+          "duration": 4,
+          "broadcastAnger": false,
+          "calm_event": {
+            "event": "minecraft:on_calm",
+            "target": "self"
+          }
+        },
+        "minecraft:behavior.ranged_attack": {
+          "priority": 2,
+          "attack_radius": 64,
+          "charge_shoot_trigger": 2,
+          "charge_charged_trigger": 1
+        }
+      },
+      "minecraft:llama_angry_wolf": {
+        "minecraft:angry": {
+          "duration": -1,
+          "broadcastAnger": false,
+          "calm_event": {
+            "event": "minecraft:on_calm",
+            "target": "self"
+          }
+        },
+        "minecraft:behavior.ranged_attack": {
+          "priority": 2,
+          "attack_radius": 64,
+          "charge_shoot_trigger": 2,
+          "charge_charged_trigger": 1
+        }
+      },
+
+      "minecraft:in_caravan": {
+        "minecraft:damage_sensor": [
+          {
+            "cause": "all",
+            "deals_damage": true
+          }
+        ]
+      }
+
+    },
+
+
+    "components": {
+      "minecraft:identifier": {
+        "id": "minecraft:llama"
+      },
+      "minecraft:type_family": {
+        "family": [ "llama" ]
+      },
+      "minecraft:breathable": {
+        "totalSupply": 15,
+        "suffocateTime": 0
+      },
+      "minecraft:nameable": {
+      },
+      "minecraft:health": {
+        "value": {
+          "range_min": 15, 
+          "range_max": 30
+        }
+      },
+      "minecraft:movement": {
+        "value": 0.25
+      },
+      "minecraft:navigation.walk": {
+        "can_float": true
+      },
+      "minecraft:movement.basic": {
+      },
+      "minecraft:jump.static": {
+      },
+      "minecraft:follow_range": {
+        "value": 40,
+        "max": 40
+      },
+      "minecraft:leashable": {
+        "soft_distance": 4.0,
+        "hard_distance": 6.0,
+        "max_distance": 10.0,
+        "on_leash": {
+          "event": "minecraft:on_leash",
+          "target": "self"
+        },
+        "on_unleash": {
+          "event": "minecraft:on_unleash",
+          "target": "self"
+        }
+      },
+      "minecraft:shooter": {
+        "type": "llamaspit",
+        "def": "minecraft:llama_spit"
+      },
+
+      "minecraft:behavior.float": {
+        "priority": 0
+      },
+      "minecraft:behavior.run_around_like_crazy": {
+        "priority": 1,
+        "speed_multiplier": 1.2
+      },
+      "minecraft:behavior.follow_caravan": {
+        "priority": 3,
+        "speed_multiplier": 2.1,
+        "entity_count": 10,
+        "entity_types": {
+          "filters": {
+            "other_with_families": [
+              "llama"
+            ]
+          }
+        }
+      },
+      "minecraft:behavior.panic": {
+        "priority": 4,
+        "speed_multiplier": 1.2
+      },
+      "minecraft:behavior.random_stroll": {
+        "priority": 6,
+        "speed_multiplier": 0.7
+      },
+      "minecraft:behavior.look_at_player": {
+        "priority": 7,
+        "look_distance": 6.0,
+        "probability": 0.02
+      },
+      "minecraft:behavior.random_look_around": {
+        "priority": 8
+      },
+      "minecraft:behavior.mount_pathing": {
+        "priority": 1,
+        "speed_multiplier": 1.25,
+        "target_dist": 0.0,
+        "track_target": true
+      },
+      "minecraft:behavior.hurt_by_target": {
+        "priority": 1,
+        "hurt_owner": true
+      },
+      "minecraft:damage_sensor": [
+        {
+          "cause": "all",
+          "deals_damage": true,
+          "on_damage": {
+            "filters": { "is_not_in_caravan": "" },
+            "event": "minecraft:become_angry"
+          }
+        }
+      ],
+      "minecraft:behavior.nearest_attackable_target": {
+        "priority": 2,
+        "attack_interval": 16,
+        "entity_types": [
+          {
+            "filters": {
+              "other_with_families": [ "wolf" ],
+              "other_without_components": [ "minecraft:is_tamed" ]
+            },
+            "max_dist": 10
+          }
+        ],
+        "must_see": false
+      },
+      "minecraft:on_target_acquired": {
+        "filters": {
+          "target_with_families": [ "wolf" ],
+          "target_without_components": [ "minecraft:is_tamed" ]
+        },
+        "event": "minecraft:mad_at_wolf",
+        "target": "self"
+      },
+      "minecraft:on_target_escape": {
+        "filters": {
+          "target_with_families": [ "wolf" ],
+          "target_without_components": [ "minecraft:is_tamed" ]
+        },
+        "event": "minecraft:on_calm",
+        "target": "self"
+      }
+
+    },
+
+
+    "events": {
+      "minecraft:entity_spawned": {
+        "sequence": [
+          {
+            "randomize": [
+              {
+                "weight": 90,
+                "remove": {
+                },
+                "add": {
+                  "component_groups": [
+                    "minecraft:llama_adult",
+                    "minecraft:llama_wild"
+                  ]
+                }
+              },
+              {
+                "weight": 10,
+                "remove": {
+                },
+                "add": {
+                  "component_groups": [
+                    "minecraft:llama_baby"
+                  ]
+
+                }
+              }
+            ]
+          },
+          {
+            "randomize": [
+              {
+                "weight": 32,
+                "add": {
+                  "component_groups": [
+                    "minecraft:strength_1"
+                  ]
+                }
+              },
+              {
+                "weight": 32,
+                "add": {
+                  "component_groups": [
+                    "minecraft:strength_2"
+                  ]
+                }
+              },
+              {
+                "weight": 32,
+                "add": {
+                  "component_groups": [
+                    "minecraft:strength_3"
+                  ]
+                }
+              },
+              {
+                "weight": 2,
+                "add": {
+                  "component_groups": [
+                    "minecraft:strength_4"
+                  ]
+                }
+              },
+              {
+                "weight": 2,
+                "add": {
+                  "component_groups": [
+                    "minecraft:strength_5"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "randomize": [
+              {
+                "weight": 25,
+                "add": {
+                  "component_groups": [
+                    "minecraft:llama_creamy"
+                  ]
+                }
+              },
+              {
+                "weight": 25,
+                "add": {
+                  "component_groups": [
+                    "minecraft:llama_white"
+                  ]
+                }
+              },
+              {
+                "weight": 25,
+                "add": {
+                  "component_groups": [
+                    "minecraft:llama_brown"
+                  ]
+                }
+              },
+              {
+                "weight": 25,
+                "add": {
+                  "component_groups": [
+                    "minecraft:llama_gray"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+
+      "minecraft:entity_born": {
+        "add": {
+          "component_groups": [
+            "minecraft:llama_baby"
+          ]
+        }
+      },
+
+      "minecraft:ageable_grow_up": {
+        "remove": {
+          "component_groups": [
+            "minecraft:llama_baby"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:llama_adult",
+            "minecraft:llama_wild"
+          ]
+        }
+      },
+
+      "minecraft:on_tame": {
+        "remove": {
+          "component_groups": [
+            "minecraft:llama_wild"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:llama_tamed",
+            "minecraft:llama_unchested"
+          ]
+        }
+      },
+
+
+      "minecraft:on_leash": {
+        "add": {
+          "component_groups": [
+            "minecraft:llama_leashed"
+          ]
+        }
+      },
+      "minecraft:on_unleash": {
+        "remove": {
+          "component_groups": [
+            "minecraft:llama_leashed"
+          ]
+        }
+      },
+      "minecraft:join_caravan": {
+        "add": {
+          "component_groups": [
+            "minecraft:in_caravan"
+          ]
+        }
+      },
+      "minecraft:leave_caravan": {
+        "remove": {
+          "component_groups": [
+            "minecraft:in_caravan"
+          ]
+        }
+      },
+      "minecraft:mad_at_wolf": {
+        "add": {
+          "component_groups": [
+            "minecraft:llama_angry_wolf"
+          ]
+        }
+      },
+      "minecraft:become_angry": {
+        "add": {
+          "component_groups": [
+            "minecraft:llama_angry"
+          ]
+        }
+      },
+      "minecraft:on_calm": {
+        "remove": {
+          "component_groups": [
+            "minecraft:llama_angry",
+            "minecraft:llama_angry_wolf"
+          ]
+        }
+      },
+
+      "minecraft:on_chest": {
+        "remove": {
+          "component_groups": [
+            "minecraft:llama_unchested"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:llama_chested"
+          ]
+        }
+      }
+
+    }
+  }
+}

--- a/resourcepacks/vanilla/server/entities/mooshroom.json
+++ b/resourcepacks/vanilla/server/entities/mooshroom.json
@@ -1,0 +1,277 @@
+{
+  "minecraft:entity": {
+    "format_version": "1.1.0",
+
+    "component_groups": {
+      "minecraft:mooshroom_become_cow": {
+        "minecraft:transformation": {
+          "into": "minecraft:cow"
+        }
+      },
+      "minecraft:cow_baby": {
+        "minecraft:is_baby": {
+        },
+        "minecraft:scale": {
+          "value":0.5
+        },
+        "minecraft:ageable": {
+          "threshold": 1200,
+          "feedItems": "wheat",
+          "grow_up": {
+            "event": "minecraft:ageable_grow_up",
+            "target": "self"
+          }
+        },
+        "minecraft:behavior.follow_parent": {
+          "priority": 6,
+          "speed_multiplier": 1.1
+        }
+      },
+
+      "minecraft:cow_adult": {
+        "minecraft:loot": {
+          "table": "loot_tables/entities/cow.json"
+        },
+        "minecraft:behavior.breed": {
+          "priority": 3,
+          "speed_multiplier": 1.0
+        },
+        "minecraft:breedable": {
+          "requireTame": false,
+          "breedItems": "wheat",
+          "breedsWith": {
+            "mateType": "minecraft:mooshroom",
+            "babyType": "minecraft:mooshroom",
+            "breed_event": {
+              "event": "minecraft:entity_born",
+              "target": "baby"
+            }
+          }
+        },
+        "minecraft:interact": [
+          {
+            "on_interact": {
+              "filters": {
+                "other_with_item": "bowl",
+                "other_with_families": "player",
+                "without_components": "minecraft:transformation"
+              }
+            },
+            "use_item": "true",
+            "transform_to_item": "mushroom_stew:0",
+            "interact_text": "action.interact.moostew"
+          },
+          {
+            "on_interact": {
+              "filters": {
+                "other_with_item": "shears",
+                "without_components": "minecraft:transformation"
+              },
+              "event": "become_cow",
+              "target": "self"
+            },
+            "use_item": false,
+            "hurt_item": 1,
+            "play_sounds": "shear",
+            "spawn_items": { "table": "loot_tables/entities/mooshroom_shear.json" },
+            "interact_text": "action.interact.mooshear"
+          },
+          {
+            "on_interact": {
+              "filters": {
+                "other_with_item": "bucket:0",
+                "other_with_families": "player"
+              }
+            },
+            "use_item": "true",
+            "transform_to_item": "bucket:1",
+            "play_sounds": "milk",
+            "interact_text": "action.interact.milk"
+          }
+        ]
+      },
+
+      "minecraft:cow_leashed": {
+        "minecraft:behavior.move_towards_restriction": {
+          "priority": 2,
+          "speed_multiplier": 1.0
+        }
+      }
+    },
+
+    "components": {
+      "minecraft:identifier": {
+        "id": "minecraft:mooshroom"
+      },
+      "minecraft:type_family": {
+        "family": [ "mushroomcow" ]
+      },
+      "minecraft:breathable": {
+        "totalSupply": 15,
+        "suffocateTime": 0
+      },
+      "minecraft:collision_box": {
+        "width": 0.9,
+        "height": 1.3
+      },
+      "minecraft:nameable": {
+      },
+      "minecraft:health": {
+        "value": 10,
+        "max": 10
+      },
+      "minecraft:movement": {
+        "value": 0.25
+      },
+      "minecraft:navigation.walk": {
+        "can_float": true,
+        "avoid_water": true
+      },
+      "minecraft:movement.basic": {
+        
+      },
+      "minecraft:jump.static": {
+      },
+      "minecraft:can_climb": {
+      },
+      "minecraft:leashable": {
+        "soft_distance": 4.0,
+        "hard_distance": 6.0,
+        "max_distance": 10.0,
+        "on_leash": {
+          "event": "minecraft:on_leash",
+          "target": "self"
+        },
+        "on_unleash": {
+          "event": "minecraft:on_unleash",
+          "target": "self"
+        }
+      },
+      "minecraft:rideable": {
+        "seat_count": 1,
+        "family_types": [
+          "zombie"
+        ],
+        "seats": {
+          "position": [0.0, 1.105, 0.0]
+        }
+      },
+      "minecraft:behavior.float": {
+        "priority": 0
+      },
+      "minecraft:behavior.panic": {
+        "priority": 1,
+        "speed_multiplier": 1.25
+      },
+      "minecraft:behavior.mount_pathing": {
+        "priority": 2,
+        "speed_multiplier": 1.5,
+        "target_dist": 0.0,
+        "track_target": true
+      },
+      "minecraft:behavior.breed": {
+        "priority": 3,
+        "speed_multiplier": 1.0
+      },
+      "minecraft:behavior.tempt": {
+        "priority": 4,
+        "speed_multiplier": 1.25,
+        "items": [
+          "wheat"
+        ]
+      },
+      "minecraft:behavior.follow_parent": {
+        "priority": 5,
+        "speed_multiplier": 1.1
+      },
+      "minecraft:behavior.random_stroll": {
+        "priority": 6,
+        "speed_multiplier": 0.8
+      },
+      "minecraft:behavior.look_at_player": {
+        "priority": 7,
+        "look_distance": 6.0,
+        "probability": 0.02
+      },
+      "minecraft:behavior.random_look_around": {
+        "priority": 9
+      }
+    },
+
+
+    "events": {
+      "become_cow": {
+        "remove": {
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:mooshroom_become_cow"
+          ]
+        }
+      },
+      "minecraft:entity_spawned": {
+        "randomize": [
+          {
+            "weight": 95,
+            "remove": {
+            },
+            "add": {
+              "component_groups": [
+                "minecraft:cow_adult"
+              ]
+            }
+          },
+          {
+            "weight": 5,
+            "remove": {
+            },
+            "add": {
+              "component_groups": [
+                "minecraft:cow_baby"
+              ]
+
+            }
+          }
+        ]
+      },
+
+      "minecraft:entity_born": {
+        "remove": {
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:cow_baby"
+          ]
+        }
+      },
+
+      "minecraft:ageable_grow_up": {
+        "remove": {
+          "component_groups": [
+            "minecraft:cow_baby"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:cow_adult"
+          ]
+        }
+      },
+
+      "minecraft:on_leash": {
+        "add": {
+          "component_groups": [
+            "minecraft:cow_leashed"
+          ]
+        }
+      },
+      "minecraft:on_unleash": {
+        "remove": {
+          "component_groups": [
+            "minecraft:cow_leashed"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/resourcepacks/vanilla/server/entities/ocelot.json
+++ b/resourcepacks/vanilla/server/entities/ocelot.json
@@ -1,0 +1,346 @@
+{
+  "minecraft:entity": {
+    "format_version": "1.1.0",
+
+    "component_groups": {
+      "minecraft:ocelot_baby": {
+        "minecraft:is_baby": {
+        },
+        "minecraft:scale": {
+          "value": 0.5
+        },
+        "minecraft:ageable": {
+          "duration": 1200,
+          "feedItems": [ "fish", "salmon" ],
+          "grow_up": {
+            "event": "minecraft:ageable_grow_up",
+            "target": "self"
+          }
+        }
+      },
+
+      "minecraft:ocelot_adult": {
+        "minecraft:scale": {
+          "value": 1
+        },
+        "minecraft:behavior.breed": {
+          "priority": 3,
+          "speed_multiplier": 1.0
+        },
+        "minecraft:breedable": {
+          "requireTame": true,
+          "allowSitting": true,
+          "breedsWith": {
+            "mateType": "minecraft:ocelot",
+            "babyType": "minecraft:ocelot",
+            "breed_event": {
+              "event": "minecraft:entity_born",
+              "target": "baby"
+            }
+          },
+          "breedItems": [ "fish", "salmon" ]
+        }
+      },
+      "minecraft:ocelot_wild": {
+        "minecraft:variant": {
+          "value": 0
+        },
+        "minecraft:tameable": {
+          "probability": 0.33,
+          "tameItems": [ "fish", "salmon" ],
+          "tame_event": {
+            "event": "minecraft:on_tame",
+            "target": "self"
+          }
+        },
+        "minecraft:behavior.avoid_mob_type": {
+          "priority": 5,
+          "entity_types": [
+            {
+              "filters": { "other_with_families": "player" },
+              "max_dist": 10,
+              "walk_speed_multiplier": 0.8,
+              "sprint_speed_multiplier": 1.33
+            }
+          ]
+        },
+        "minecraft:behavior.nearest_attackable_target": {
+          "priority": 1,
+          "attack_interval": 10,
+          "entity_types": [
+            {
+              "filters": { "other_with_families": "chicken" },
+              "max_dist": 8
+            }
+          ]
+        },
+        "minecraft:rideable": {
+          "seat_count": 1,
+          "family_types": [
+            "zombie"
+          ],
+          "seats": {
+            "position": [0.0, 0.35, 0.0]
+          }
+        }
+      },
+      "minecraft:ocelot_tame": {
+        "minecraft:is_tamed": {
+        },
+        "minecraft:health": {
+          "value": 20,
+          "max": 20
+        },
+        "minecraft:sittable": {
+        },
+        "minecraft:leashable": {
+          "soft_distance": 4.0,
+          "hard_distance": 6.0,
+          "max_distance": 10.0,
+          "on_leash": {
+            "event": "minecraft:on_leash",
+            "target": "self"
+          },
+          "on_unleash": {
+            "event": "minecraft:on_unleash",
+            "target": "self"
+          }
+        },
+        "minecraft:behavior.follow_owner": {
+          "priority": 4,
+          "speed_multiplier": 1.0,
+          "start_distance": 10,
+          "stop_distance": 2
+        },
+        "minecraft:behavior.stay_while_sitting": {
+          "priority": 3
+        },
+        "minecraft:behavior.ocelot_sit_on_block": {
+          "priority": 6,
+          "speed_multiplier": 1.0
+        }
+      },
+      "minecraft:ocelot_leashed": {
+        "minecraft:behavior.move_towards_restriction": {
+          "priority": 2,
+          "speed_multiplier": 1.0
+        }
+      },
+      "minecraft:ocelot_tuxedo": {
+        "minecraft:variant": {
+          "value": 1
+        }
+      },
+      "minecraft:ocelot_tabby": {
+        "minecraft:variant": {
+          "value": 2
+        }
+      },
+      "minecraft:ocelot_siamese": {
+        "minecraft:variant": {
+          "value": 3
+        }
+      }
+    },
+
+    "components": {
+      "minecraft:attack_damage": {
+        "value": 4
+      },
+      "minecraft:identifier": {
+        "id": "minecraft:ocelot"
+      },
+      "minecraft:nameable": {
+      },
+      "minecraft:type_family": {
+        "family": [ "ocelot" ]
+      },
+      "minecraft:breathable": {
+        "totalSupply": 15,
+        "suffocateTime": 0
+      },
+      "minecraft:health": {
+        "value": 10,
+        "max": 10
+      },
+      "minecraft:collision_box": {
+        "width": 0.6,
+        "height": 0.7
+      },
+      "minecraft:movement": {
+        "value": 0.3
+      },
+      "minecraft:navigation.walk": {
+        "can_float": true,
+        "avoid_water": true
+      },
+      "minecraft:movement.basic": {
+        
+      },
+      "minecraft:jump.static": {
+      },
+      "minecraft:can_climb": {
+      },
+      "minecraft:fall_damage": {
+        "value": 0.0
+      },
+      "minecraft:behavior.float": {
+        "priority": 0
+      },
+      "minecraft:behavior.tempt": {
+        "priority": 4,
+        "speed_multiplier": 0.5,
+        "within_radius": 16,
+        "can_get_scared": true,
+        "items": [
+          "fish",
+          "salmon"
+        ]
+      },
+      "minecraft:behavior.mount_pathing": {
+        "priority": 1,
+        "speed_multiplier": 1.25,
+        "target_dist": 0,
+        "track_target": true
+      },
+      "minecraft:behavior.ocelot_sit_on_block": {
+        "priority": 2,
+        "speed_multiplier": 0.8
+      },
+      "minecraft:behavior.leap_at_target": {
+        "priority": 3,
+        "target_dist": 0.3
+      },
+      "minecraft:behavior.ocelotattack": {
+        "priority": 4,
+        "walk_speed_multiplier": 0.8,
+        "sprint_speed_multiplier": 1.33,
+        "sneak_speed_multiplier": 0.6
+      },
+      "minecraft:behavior.random_stroll": {
+        "priority": 8,
+        "speed_multiplier": 0.8
+      },
+      "minecraft:behavior.look_at_player": {
+        "priority": 9
+      }
+    },
+
+    "events": {
+      "minecraft:entity_spawned": {
+        "sequence": [
+          {
+            "randomize": [
+              {
+                "weight": 3,
+                "remove": {
+                },
+                "add": {
+                  "component_groups": [
+                    "minecraft:ocelot_adult",
+                    "minecraft:ocelot_wild"
+                  ]
+                }
+              },
+              {
+                "weight": 1,
+                "remove": {
+                },
+                "add": {
+                  "component_groups": [
+                    "minecraft:ocelot_baby",
+                    "minecraft:ocelot_wild"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+
+      "minecraft:entity_born": {
+        "remove": {
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:ocelot_baby",
+            "minecraft:ocelot_tame"
+          ]
+        }
+      },
+
+      "minecraft:ageable_grow_up": {
+        "remove": {
+          "component_groups": [
+            "minecraft:ocelot_baby"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:ocelot_adult"
+          ]
+        }
+      },
+      "minecraft:on_tame": {
+        "sequence": [
+          {
+            "remove": {
+              "component_groups": [
+                "minecraft:ocelot_wild"
+              ]
+            }
+          },
+          {
+            "add": {
+              "component_groups": [
+                "minecraft:ocelot_tame"
+              ]
+            }
+          },
+          {
+            "randomize": [
+              {
+                "weight": 30,
+                "add": {
+                  "component_groups": [
+                    "minecraft:ocelot_tabby"
+                  ]
+                }
+              },
+              {
+                "weight": 30,
+                "add": {
+                  "component_groups": [
+                    "minecraft:ocelot_tuxedo"
+                  ]
+                }
+              },
+              {
+                "weight": 30,
+                "add": {
+                  "component_groups": [
+                    "minecraft:ocelot_siamese"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "minecraft:on_leash": {
+        "add": {
+          "component_groups": [
+            "minecraft:ocelot_leashed"
+          ]
+        }
+      },
+      "minecraft:on_unleash": {
+        "remove": {
+          "component_groups": [
+            "minecraft:ocelot_leashed"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/resourcepacks/vanilla/server/entities/polar_bear.json
+++ b/resourcepacks/vanilla/server/entities/polar_bear.json
@@ -1,0 +1,256 @@
+{
+  "minecraft:entity": {
+    "version": 0.5,
+
+    "component_groups": {
+      "minecraft:baby": {
+        "minecraft:is_baby": {
+        },
+        "minecraft:scale": {
+          "value": 0.5
+        },
+        "minecraft:ageable": {
+          "duration": 1200,
+          "grow_up": {
+            "event": "minecraft:ageable_grow_up",
+            "target": "self"
+          }
+        },
+
+        "minecraft:behavior.follow_parent": {
+          "priority": 4,
+          "speed_multiplier": 1.25
+        }
+      },
+
+      "minecraft:baby_wild": {
+        "minecraft:on_target_acquired": {
+          "event": "minecraft:on_scared",
+          "target": "self"
+        },
+
+        "minecraft:behavior.panic": {
+          "priority": 1,
+          "speed_multiplier": 2.0
+        },
+        "minecraft:behavior.nearest_attackable_target": {
+          "priority": 4,
+          "entity_types": [
+            {
+              "filters": { "other_with_families": "player" },
+              "max_dist": 16
+            }
+          ],
+          "must_see": false
+        }
+      },
+
+      "minecraft:baby_scared": {
+        "minecraft:angry": {
+          "duration": 1,
+          "broadcastAnger": true,
+          "broadcastRange": 41,
+          "calm_event": {
+            "event": "minecraft:baby_on_calm",
+            "target": "self"
+          }
+        }
+      },
+
+      "minecraft:adult": {
+        "minecraft:loot": {
+          "table": "loot_tables/gameplay/fishing/fish.json"
+        }
+      },
+
+      "minecraft:adult_wild": {
+        "minecraft:on_target_acquired": {
+          "event": "minecraft:on_anger",
+          "target": "self"
+        },
+        "minecraft:on_friendly_anger": {
+          "event": "minecraft:on_anger",
+          "target": "self"
+        }
+      },
+
+      "minecraft:adult_hostile": {
+        "minecraft:attack": {
+          "damage": 6.0
+        },
+        "minecraft:angry": {
+          "duration": 500,
+          "broadcastAnger": false,
+          "broadcastRange": 20,
+          "calm_event": {
+            "event": "minecraft:on_calm",
+            "target": "self"
+          }
+        },
+
+        "minecraft:behavior.stomp_attack": {
+          "priority": 1,
+          "track_target": true
+        }
+      }
+    },
+
+    "components": {
+      "minecraft:identifier": {
+        "id": "minecraft:polar_bear"
+      },
+      "minecraft:type_family": {
+        "family": [ "polarbear" ]
+      },
+      "minecraft:breathable": {
+        "totalSupply": 15,
+        "suffocateTime": 0
+      },
+      "minecraft:nameable": {
+      },
+      "minecraft:health": {
+        "value": 30
+      },
+      "minecraft:collision_box": {
+        "width": 1.3,
+        "height": 1.4
+      },
+      "minecraft:movement": {
+        "value": 0.25
+      },
+      "minecraft:navigation.walk": {
+        "can_float": true
+      },
+      "minecraft:movement.basic": {
+        
+      },
+      "minecraft:jump.static": {
+      },
+      "minecraft:can_climb": {
+      },
+      "minecraft:follow_range": {
+        "value": 48
+      },
+
+      "minecraft:behavior.float": {
+        "priority": 0
+      },
+      "minecraft:behavior.hurt_by_target": {
+        "priority": 1
+      },
+      "minecraft:behavior.random_stroll": {
+        "priority": 5
+      },
+      "minecraft:behavior.look_at_player": {
+        "priority": 6,
+        "target_distance": 6.0,
+        "probability": 0.02
+      },
+      "minecraft:behavior.random_look_around": {
+        "priority": 7
+      }
+    },
+
+    "events": {
+      "minecraft:entity_spawned": {
+        "randomize": [
+          {
+            "weight": 9,
+            "add": {
+              "component_groups": [
+                "minecraft:adult",
+                "minecraft:adult_wild"
+              ]
+            }
+          },
+          {
+            "weight": 1,
+            "add": {
+              "component_groups": [
+                "minecraft:baby",
+                "minecraft:baby_wild"
+              ]
+            }
+          }
+        ]
+      },
+
+      "minecraft:entity_born": {
+        "add": {
+          "component_groups": [
+            "minecraft:baby",
+            "minecraft:baby_wild"
+          ]
+        }
+      },
+
+      "minecraft:ageable_grow_up": {
+        "remove": {
+          "component_groups": [
+            "minecraft:baby",
+            "minecraft:baby_wild",
+            "minecraft:baby_scared"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:adult",
+            "minecraft:adult_wild"
+          ]
+        }
+      },
+
+      "minecraft:on_calm": {
+        "remove": {
+          "component_groups": [
+            "minecraft:adult_hostile"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:adult_wild"
+          ]
+        }
+      },
+
+      "minecraft:on_anger": {
+        "remove": {
+          "component_groups": [
+            "minecraft:adult_wild"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:adult_hostile"
+          ]
+        }
+      },
+
+      "minecraft:baby_on_calm": {
+        "remove": {
+          "component_groups": [
+            "minecraft:baby_scared"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:baby_wild"
+          ]
+        }
+      },
+
+      "minecraft:on_scared": {
+        "remove": {
+          "component_groups": [
+            "minecraft:baby_wild"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:baby_scared"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/resourcepacks/vanilla/server/entities/silverfish.json
+++ b/resourcepacks/vanilla/server/entities/silverfish.json
@@ -1,0 +1,125 @@
+{
+  "minecraft:entity": {
+    "format_version": "1.1.0",
+
+    "component_groups": {
+      "minecraft:silverfish_calm": {
+        "minecraft:on_target_acquired" : {
+					"event": "minecraft:become_angry",
+					"target": "self"
+				}
+      },
+      "minecraft:silverfish_angry": {
+        "minecraft:angry": {
+          "duration": -1,
+          "broadcastAnger": true,
+          "broadcastRange": 20,
+          "calm_event": {
+            "event": "minecraft:on_calm",
+            "target": "self"
+          }
+        },
+     "minecraft:behavior.melee_attack": {
+				  "priority": 4,
+				  "speed_multiplier": 1.0,
+				  "track_target": true
+			  },
+        "minecraft:behavior.silverfish_wake_up_friends": {
+          "priority": 1
+        }
+      }
+    },
+
+	"components": {
+	  "minecraft:identifier": {
+		  "id": "minecraft:silverfish"
+	  },
+	  "minecraft:type_family": {
+		  "family":["silverfish", "monster", "arthropod" ]          
+	  },
+      "minecraft:breathable": {
+        "totalSupply": 15,
+        "suffocateTime": 0
+      },
+	  "minecraft:nameable": {
+	  },
+      "minecraft:health": {
+        "value": 8,
+        "max": 8
+      },	
+			"minecraft:movement": {
+				"value": 0.25
+			},
+      "minecraft:navigation.walk": {
+        "can_float": true
+      },
+      "minecraft:movement.basic": {
+        
+      },
+      "minecraft:jump.static": {
+      },
+      "minecraft:can_climb": {
+      },
+			"minecraft:attack": {
+				"damage": 1
+			},
+      "minecraft:collision_box": {
+				"width": 0.4,
+				"height": 0.3
+			},
+
+      "minecraft:behavior.float": {
+        "priority": 1
+      },      
+      "minecraft:behavior.silverfish_merge_with_stone": {
+        "priority": 5
+      },
+      "minecraft:behavior.nearest_attackable_target": {
+        "priority": 2,
+        "entity_types": [
+          {
+            "filters": { "other_with_families": [ "player", "irongolem", "snowgolem" ] },
+            "max_dist": 8,
+            "attack_interval": 10
+          }
+        ]
+      },
+      "minecraft:behavior.hurt_by_target": {
+        "priority": 1,
+        "alert_same_type": true
+      }
+		},
+
+    "events": {
+      "minecraft:entity_spawned": {
+				"remove": {
+				},
+				"add": {
+					"component_groups": [
+						"minecraft:silverfish_calm"
+					]
+				}
+			},
+      "minecraft:become_angry": {
+        "remove": {
+          "minecraft:silverfish_calm": { }
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:silverfish_angry"
+          ]
+        }
+      },
+      "minecraft:on_calm": {
+        "remove": {
+          "minecraft:silverfish_angry": { }
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:silverfish_calm"
+          ]
+        }
+      }
+    }
+	}
+}

--- a/resourcepacks/vanilla/server/entities/wolf.json
+++ b/resourcepacks/vanilla/server/entities/wolf.json
@@ -1,0 +1,465 @@
+{
+  "minecraft:entity": {
+    "format_version": "1.1.0",
+
+    "component_groups": {
+      "minecraft:wolf_baby": {
+        "minecraft:is_baby": {
+        },
+        "minecraft:scale": {
+          "value": 0.5
+        },
+
+        "minecraft:ageable": {
+          "duration": 1200,
+          "feedItems": [
+            "chicken",
+            "cooked_chicken",
+            "beef",
+            "cooked_beef",
+            "muttonRaw",
+            "muttonCooked",
+            "porkchop",
+            "cooked_porkchop",
+            "rabbit",
+            "cooked_rabbit",
+            "rotten_flesh"
+          ],
+          "grow_up": {
+            "event": "minecraft:ageable_grow_up",
+            "target": "self"
+          }
+        }
+      },
+
+      "minecraft:wolf_adult": {
+        "minecraft:breedable": {
+          "requireTame": true,
+          "breedsWith": {
+            "mateType": "minecraft:wolf",
+            "babyType": "minecraft:wolf",
+            "breed_event": {
+              "event": "minecraft:entity_born",
+              "target": "baby"
+            }
+          },
+          "breedItems": [
+            "chicken",
+            "cooked_chicken",
+            "beef",
+            "cooked_beef",
+            "muttonRaw",
+            "muttonCooked",
+            "porkchop",
+            "cooked_porkchop",
+            "rabbit",
+            "cooked_rabbit",
+            "rotten_flesh"
+          ]
+        }
+      },
+
+      "minecraft:wolf_angry": {
+        "minecraft:angry": {
+          "duration": 25,
+          "broadcastAnger": true,
+          "broadcastRange": 20,
+          "calm_event": {
+            "event": "minecraft:on_calm",
+            "target": "self"
+          }
+        },
+        "minecraft:on_target_acquired": {
+        }
+      },
+
+      "minecraft:wolf_wild": {
+        "minecraft:behavior.avoid_mob_type": {
+          "priority": 3,
+          "entity_types": [
+            {
+              "filters": { "other_with_families": "llama" },
+              "max_dist": 24,
+              "walk_speed_multiplier": 1.5,
+              "sprint_speed_multiplier": 1.5
+            }
+          ],
+          "probability_per_strength": 0.14
+        },
+        "minecraft:tameable": {
+          "probability": 0.33,
+          "tameItems": "bone",
+          "tame_event": {
+            "event": "minecraft:on_tame",
+            "target": "self"
+          }
+        },
+
+        "minecraft:behavior.nearest_attackable_target": {
+          "priority": 4,
+          "attack_interval": 10,
+          "entity_types": [
+            {
+              "filters": { "other_with_families": [ "skeleton", "sheep", "rabbit" ] },
+              "max_dist": 16
+            }
+          ],
+          "must_see": true
+        },
+        "minecraft:on_target_acquired": {
+          "event": "minecraft:become_angry",
+          "target": "self"
+        },
+        "minecraft:rideable": {
+          "seat_count": 1,
+          "family_types": [
+            "zombie"
+          ],
+          "seats": {
+            "position": [ 0.0, 0.675, -0.1 ]
+          }
+        }
+      },
+
+      "minecraft:wolf_tame": {
+        "minecraft:is_tamed": {
+        },
+        "minecraft:health": {
+          "value": 20,
+          "max": 20
+        },
+        "minecraft:color": {
+          "value": 14
+        },
+        "minecraft:behavior.follow_owner": {
+          "priority": 6,
+          "speed_multiplier": 1.0,
+          "start_distance": 10,
+          "stop_distance": 2
+        },
+        "minecraft:attack": {
+          "damage": 4
+        },
+        "minecraft:behavior.breed": {
+          "priority": 7
+        },
+
+        "minecraft:behavior.owner_hurt_by_target": {
+          "priority": 1
+        },
+        "minecraft:behavior.owner_hurt_target": {
+          "priority": 2
+        },
+        "minecraft:behavior.nearest_attackable_target": {
+          "priority": 5,
+          "attack_interval": 10,
+          "entity_types": [
+            {
+              "filters": { "other_with_families": "skeleton" },
+              "max_dist": 16
+            }
+          ],
+          "must_see": true
+        },
+
+        "minecraft:sittable": {
+        },
+        "minecraft:is_dyeable": {
+          "interact_text": "action.interact.dye"
+        },
+
+        "minecraft:leashable": {
+          "soft_distance": 4.0,
+          "hard_distance": 6.0,
+          "max_distance": 10.0,
+          "on_leash": {
+            "event": "minecraft:on_leash",
+            "target": "self"
+          },
+          "on_unleash": {
+            "event": "minecraft:on_unleash",
+            "target": "self"
+          }
+        }
+      },
+
+      "minecraft:wolf_leashed": {
+        "minecraft:behavior.move_towards_restriction": {
+          "priority": 2,
+          "speed_multiplier": 1.0
+        }
+      }
+    },
+
+
+    "components": {
+      "minecraft:identifier": {
+        "id": "minecraft:wolf"
+      },
+      "minecraft:nameable": {
+      },
+      "minecraft:type_family": {
+        "family": [ "wolf" ]
+      },
+      "minecraft:breathable": {
+        "totalSupply": 15,
+        "suffocateTime": 0
+      },
+      "minecraft:collision_box": {
+        "width": 0.6,
+        "height": 0.8
+      },
+      "minecraft:health": {
+        "value": 8,
+        "max": 8
+      },
+      "minecraft:movement": {
+        "value": 0.3
+      },
+      "minecraft:navigation.walk": {
+        "can_float": true
+      },
+      "minecraft:movement.basic": {
+      },
+      "minecraft:jump.static": {
+      },
+      "minecraft:can_climb": {
+      },
+      "minecraft:attack": {
+        "damage": 3
+      },
+      "minecraft:healable": {
+        "items": [
+          {
+            "item": "porkchop",
+            "heal_amount": 3
+          },
+          {
+            "item": "cooked_porkchop",
+            "heal_amount": 8
+          },
+          {
+            "item": "fish",
+            "heal_amount": 2
+          },
+          {
+            "item": "salmon",
+            "heal_amount": 2
+          },
+          {
+            "item": "clownfish",
+            "heal_amount": 1
+          },
+          {
+            "item": "pufferfish",
+            "heal_amount": 1
+          },
+          {
+            "item": "cooked_fish",
+            "heal_amount": 5
+          },
+          {
+            "item": "cooked_salmon",
+            "heal_amount": 6
+          },
+          {
+            "item": "beef",
+            "heal_amount": 3
+          },
+          {
+            "item": "cooked_beef",
+            "heal_amount": 8
+          },
+          {
+            "item": "chicken",
+            "heal_amount": 2
+          },
+          {
+            "item": "cooked_chicken",
+            "heal_amount": 6
+          },
+          {
+            "item": "muttonRaw",
+            "heal_amount": 2
+          },
+          {
+            "item": "muttonCooked",
+            "heal_amount": 6
+          },
+          {
+            "item": "rotten_flesh",
+            "heal_amount": 4
+          },
+          {
+            "item": "rabbit",
+            "heal_amount": 3
+          },
+          {
+            "item": "cooked_rabbit",
+            "heal_amount": 5
+          },
+          {
+            "item": "rabbit_stew",
+            "heal_amount": 10
+          }
+        ]
+      },
+      "minecraft:behavior.float": {
+        "priority": 0
+      },
+      "minecraft:behavior.mount_pathing": {
+        "priority": 1,
+        "speed_multiplier": 1.25,
+        "target_dist": 0,
+        "track_target": true
+      },
+      "minecraft:behavior.stay_while_sitting": {
+        "priority": 3
+      },
+      "minecraft:behavior.leap_at_target": {
+        "priority": 4,
+        "target_dist": 0.4
+      },
+      "minecraft:behavior.melee_attack": {
+        "priority": 5,
+        "target_dist": 1.2,
+        "track_target": true,
+        "reach_multiplier": 1.0
+      },
+      "minecraft:behavior.random_stroll": {
+        "priority": 8,
+        "speed_multiplier": 1.0
+      },
+      "minecraft:behavior.beg": {
+        "priority": 9,
+        "look_distance": 8,
+        "look_time": [ 2, 4 ],
+        "items": [ "bone" ]
+      },
+
+      "minecraft:behavior.hurt_by_target": {
+        "priority": 3
+      }
+    },
+
+
+    "events": {
+      "minecraft:entity_spawned": {
+        "randomize": [
+          {
+            "weight": 9,
+            "remove": {
+            },
+            "add": {
+              "component_groups": [
+                "minecraft:wolf_adult",
+                "minecraft:wolf_wild"
+              ]
+            }
+          },
+          {
+            "weight": 1,
+            "remove": {
+            },
+            "add": {
+              "component_groups": [
+                "minecraft:wolf_baby",
+                "minecraft:wolf_wild"
+              ]
+
+            }
+          }
+        ]
+      },
+
+      "minecraft:entity_born": {
+        "remove": {
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:wolf_baby",
+            "minecraft:wolf_tame"
+          ]
+        }
+      },
+
+      "minecraft:ageable_grow_up": {
+        "remove": {
+          "component_groups": [
+            "minecraft:wolf_baby"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:wolf_adult"
+          ]
+        }
+      },
+
+      "minecraft:ageable_set_baby": {
+        "remove": {
+          "component_groups": [
+            "minecraft:wolf_adult"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:wolf_baby"
+          ]
+        }
+      },
+
+      "minecraft:on_tame": {
+        "remove": {
+          "component_groups": [
+            "minecraft:wolf_wild"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:wolf_tame"
+          ]
+        }
+      },
+      "minecraft:become_angry": {
+        "remove": {
+          "component_groups": [
+            "minecraft:wolf_wild"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:wolf_angry"
+          ]
+        }
+      },
+      "minecraft:on_calm": {
+        "remove": {
+          "component_groups": [
+            "minecraft:wolf_angry"
+          ]
+        },
+        "add": {
+          "component_groups": [
+            "minecraft:wolf_wild"
+          ]
+        }
+      },
+
+      "minecraft:on_leash": {
+        "add": {
+          "component_groups": [
+            "minecraft:wolf_leashed"
+          ]
+        }
+      },
+      "minecraft:on_unleash": {
+        "remove": {
+          "component_groups": [
+            "minecraft:wolf_leashed"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/resourcepacks/vanilla/server/entities/zombie_horse.json
+++ b/resourcepacks/vanilla/server/entities/zombie_horse.json
@@ -1,0 +1,129 @@
+{
+  "minecraft:entity": {
+    "format_version": "1.1.0",
+
+    "component_groups": {
+      "minecraft:zombie_horse_leashed": {
+        "minecraft:behavior.move_towards_restriction": {
+          "priority": 2,
+          "speed_multiplier": 1.0
+        }
+      }
+    },
+
+    "components": {
+      "minecraft:identifier": {
+        "id": "minecraft:zombie_horse"
+      },
+      "minecraft:type_family": {
+        "family": [ "zombiehorse", "undead" ]
+      },
+      "minecraft:breathable": {
+        "totalSupply": 15,
+        "suffocateTime": 0
+      },
+      "minecraft:collision_box": {
+        "width": 1.4,
+        "height": 1.6
+      },
+      "minecraft:health": {
+        "value": 15,
+        "max": 15
+      },
+      "minecraft:loot": {
+        "table": "loot_tables/entities/zombie.json"
+      },
+      "minecraft:movement": {
+        "value": 0.2
+      },
+      "minecraft:navigation.walk": {
+        "can_float": true,
+        "avoid_water": true
+      },
+      "minecraft:movement.basic": {
+      },
+      "minecraft:jump.static": {
+      },
+      "minecraft:nameable": {
+      },
+      "minecraft:is_tamed": {
+      },
+      "minecraft:horse.jump_strength": {
+        "value": {
+          "range_min": 0.4, 
+          "range_max": 1.0
+        }
+      },
+      "minecraft:leashable": {
+        "soft_distance": 4.0,
+        "hard_distance": 6.0,
+        "max_distance": 10.0,
+        "on_leash": {
+          "event": "minecraft:on_leash",
+          "target": "self"
+        },
+        "on_unleash": {
+          "event": "minecraft:on_unleash",
+          "target": "self"
+        }
+      },
+      "minecraft:behavior.float": {
+        "priority": 0
+      },
+      "minecraft:behavior.panic": {
+        "priority": 1,
+        "speed_multiplier": 1.2
+      },
+      "minecraft:behavior.random_stroll": {
+        "priority": 6,
+        "speed_multiplier": 0.7
+      },
+      "minecraft:behavior.look_at_player": {
+        "priority": 7,
+        "look_distance": 6.0,
+        "probability": 0.02
+      },
+      "minecraft:behavior.random_look_around": {
+        "priority": 8
+      },
+
+      "minecraft:rideable": {
+        "priority": 0,
+        "seat_count": 1,
+        "family_types": [
+          "zombie"
+        ],
+        "interact_text": "action.interact.ride.horse",
+        "seats": {
+          "position": [0.0, 1.2, -0.2]
+        }
+      },
+      "minecraft:behavior.mount_pathing": {
+        "priority": 2,
+        "speed_multiplier": 1.5,
+        "target_dist": 0.0,
+        "track_target": true
+      },
+      "minecraft:behavior.player_ride_tamed": {
+
+      }
+    },
+
+    "events": {
+      "minecraft:on_leash": {
+        "add": {
+          "component_groups": [
+            "minecraft:zombie_horse_leashed"
+          ]
+        }
+      },
+      "minecraft:on_unleash": {
+        "remove": {
+          "component_groups": [
+            "minecraft:zombie_horse_leashed"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/resourcepacks/vanilla/server/entities/zombie_husk.json
+++ b/resourcepacks/vanilla/server/entities/zombie_husk.json
@@ -57,47 +57,6 @@
 				"sound_event": "prepare.summon"			
               }
             ]
-          },
-          {
-            "min_activation_range": 2.0,
-            "weight": 6,
-            "cooldown_time": 30.0,
-            "cast_duration": 0.2,
-            "particle_color": "#00664D59",
-            "start_sound_event": "cast.spell",
-            "sequence": [
-              {
-                "shape": "line",
-                "target": "self",
-                "base_delay": 0.1,
-                "delay_per_summon": 0.1,
-                "num_entities_spawned": 1,
-                "entity_type": "minecraft:husk",
-				"summon_cap": 2,	
-                "size": 1,
-                "summon_cap_radius": 40.0,				
-				"sound_event": "prepare.summon"	
-              }
-            ]
-          },
-          {
-            "weight": 5,
-            "cooldown_time": 35.0,
-            "cast_duration": 0.1,
-            "particle_color": "#00B3B3CC",
-            "sequence": [
-              {
-                "shape": "circle",
-                "target": "self",
-                "base_delay": 5.0,
-                "num_entities_spawned": 1,
-                "entity_type": "minecraft:husk",
-                "summon_cap": 2,
-                "summon_cap_radius": 40.0,
-                "size": 1,
-                "sound_event": "prepare.summon"
-              }
-            ]
           }
         ]
       }			  
@@ -243,7 +202,7 @@
             }
           },
           {
-            "weight": 10,
+            "weight": 5,
             "remove": {
             },
             "add": {

--- a/resourcepacks/vanilla/server/entities/zombie_villager.json
+++ b/resourcepacks/vanilla/server/entities/zombie_villager.json
@@ -311,9 +311,6 @@
       },
       "minecraft:loot": {
         "table": "loot_tables/entities/zombie.json"
-      },
-      "minecraft:equipment": {
-        "table": "loot_tables/entities/zombie_equipment.json"
       },      
       "minecraft:collision_box": {
         "width": 0.6,

--- a/resourcepacks/vanilla/server/loot_tables/gameplay/fishing/fish.json
+++ b/resourcepacks/vanilla/server/loot_tables/gameplay/fishing/fish.json
@@ -1,0 +1,81 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:fish",
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 0
+                        },
+                        {
+                            "function": "looting_enchant",
+                            "count": {
+                                "min": 0,
+                                "max": 1
+                            }
+                        }                        
+                    ],
+                    "weight": 60
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:fish",
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 1
+                        },
+                        {
+                            "function": "looting_enchant",
+                            "count": {
+                                "min": 0,
+                                "max": 1
+                            }
+                        }                        
+                    ],
+                    "weight": 25
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:fish",
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 2
+                        },
+                        {
+                            "function": "looting_enchant",
+                            "count": {
+                                "min": 0,
+                                "max": 1
+                            }
+                        }                        
+                    ],
+                    "weight": 2
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:fish",
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "looting_enchant",
+                            "count": {
+                                "min": 0,
+                                "max": 1
+                            }
+                        }                        
+                    ],
+                    "weight": 13
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
removed duplicate loot tables by replacing them with calls to existing ones, removed zombie villagers wearing armor due to visual bugs with no known fix.